### PR TITLE
Update to CDK 2.44.0.  This includes changing two of the EC2 Subnet c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,17 @@ If you would like to familiarize yourself the [CDKWorkshop](https://cdkworkshop.
 Using Cloud9 environment, open a new Terminal and use the following commands:
 ```bash
 cd ~/environment/aws-mlflow-sagemaker-cdk/cdk/nginxAuthentication
-npm install -g aws-cdk@2.22.0 --force
+npm install -g aws-cdk@2.44.0 --force
 cdk --version
 ```
 
-Take a note of the latest version that you install, at the time of writing this post it is `2.22.0`.
-Open the package.json file and replace the version “2.22.0” of the following modules with the latest version that you have installed above.
+Take a note of the latest version that you install, at the time of writing this post it is `2.44.0`.
+Open the package.json file and replace the version “2.44.0” of the following modules with the latest version that you have installed above.
 
 ```typescript
-"aws-cdk-lib": "2.22.0",
-"@aws-cdk/aws-apigatewayv2-alpha": "2.22.0-alpha.0",
-"@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.22.0-alpha.0",
+"aws-cdk-lib": "2.44.0",
+"@aws-cdk/aws-apigatewayv2-alpha": "2.44.0-alpha.0",
+"@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.44.0-alpha.0",
 ```
 
 This will install all the latest CDK modules under the `node_modules` directory (`npm install`) and prepare your AWS account to deploy resources with CDK (`cdk bootstrap`).

--- a/cdk/nginxAuthentication/lib/mlflow-vpc-stack.ts
+++ b/cdk/nginxAuthentication/lib/mlflow-vpc-stack.ts
@@ -52,12 +52,12 @@ export class MLflowVpcStack extends cdk.Stack {
         },
         {
           name: 'private',
-          subnetType: ec2.SubnetType.PRIVATE,
+          subnetType: ec2.SubnetType.PRIVATE_WITH_NAT,
           cidrMask: 26,
         },
         {
           name: 'isolated',
-          subnetType: ec2.SubnetType.ISOLATED,
+          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
           cidrMask: 28,
         },
       ],

--- a/cdk/nginxAuthentication/package-lock.json
+++ b/cdk/nginxAuthentication/package-lock.json
@@ -14,12 +14,12 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.22.0-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.22.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.44.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.44.0-alpha.0",
         "@types/jest": "^26.0.10",
         "@types/node": "10.17.27",
-        "aws-cdk": "2.22.0",
-        "aws-cdk-lib": "2.22.0",
+        "aws-cdk": "2.44.0",
+        "aws-cdk-lib": "2.44.0",
         "jest": "^26.4.2",
         "ts-jest": "^26.2.0",
         "ts-node": "^9.0.0",
@@ -27,29 +27,29 @@
       }
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.22.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.22.0-alpha.0.tgz",
-      "integrity": "sha512-O8ZY2ny8TapdvD6iIULzBKJ4rn9JlmkwfDzfR7cYl7y+P220sLh1iJmU/m1yqtIRMLjv2022XCNBMZUJfwpVqQ==",
+      "version": "2.44.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.44.0-alpha.0.tgz",
+      "integrity": "sha512-hQGYHa8OhgEQWKj6wNd7I+bOdXANu9RiWMNOyBJszZEo7v0rmUGQA02FtSOnG0jTsoiiSbKuGPkvMR3Us2OGwQ==",
       "dev": true,
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.22.0",
+        "aws-cdk-lib": "^2.44.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.22.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.22.0-alpha.0.tgz",
-      "integrity": "sha512-QVXHA8J6ECkE29aT3Rnwtgxq15eDW3SlMuX8Z9J3BVqPPAH7rLAruD3hKL//KklVFd8xke7zBxMeYJ5CGkduZA==",
+      "version": "2.44.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.44.0-alpha.0.tgz",
+      "integrity": "sha512-1ObXcC1AW4O2wx0xGLnXiw+QrnVGzuVBoK5v9tMxmzWA4Bo2ms4u3FL/3Ill36Q4925uqbRNdVS8zjN71DTAmQ==",
       "dev": true,
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.22.0-alpha.0",
-        "aws-cdk-lib": "^2.22.0",
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.44.0-alpha.0",
+        "aws-cdk-lib": "^2.44.0",
         "constructs": "^10.0.0"
       }
     },
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.22.0.tgz",
-      "integrity": "sha512-oF3VCv/rtuLk8eLb6CBEWvEobabG8q05ersawGEy9CBhKbKNjfY1FDz6gc3ssksTwfcJqyJms2l/BQlLMBjugw==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.44.0.tgz",
+      "integrity": "sha512-9hbK4Yc1GQ28zSjZE2ajidt7sRrTLYpijkI7HT7JcDhXLe2ZGP9EOZrqKy5EEsOv0wDQ7cdXB3/oMiMGSmSQ5A==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.22.0.tgz",
-      "integrity": "sha512-Orz+c746XGm1QBJKb3Wh6qH2rpmHdYMS5A4Wk91niYzrY4Q2kck/XLeQtEwOzscbW2Hqwc6vXTEpkldAI2pzGw==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.44.0.tgz",
+      "integrity": "sha512-h0lCcS3t2TPF5FIpkA7OcE2t4vChtz/FGcZ5jVaORj21quiUz84eOhGk2BeRoKqfSp1Zqu2QxQUk6p6YpAOrRA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1157,10 +1157,10 @@
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1259,7 +1259,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1268,12 +1268,15 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "7.8.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -1298,18 +1301,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.6",
+      "version": "7.3.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
@@ -1320,6 +1323,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -5980,16 +5989,16 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.22.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.22.0-alpha.0.tgz",
-      "integrity": "sha512-O8ZY2ny8TapdvD6iIULzBKJ4rn9JlmkwfDzfR7cYl7y+P220sLh1iJmU/m1yqtIRMLjv2022XCNBMZUJfwpVqQ==",
+      "version": "2.44.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.44.0-alpha.0.tgz",
+      "integrity": "sha512-hQGYHa8OhgEQWKj6wNd7I+bOdXANu9RiWMNOyBJszZEo7v0rmUGQA02FtSOnG0jTsoiiSbKuGPkvMR3Us2OGwQ==",
       "dev": true,
       "requires": {}
     },
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.22.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.22.0-alpha.0.tgz",
-      "integrity": "sha512-QVXHA8J6ECkE29aT3Rnwtgxq15eDW3SlMuX8Z9J3BVqPPAH7rLAruD3hKL//KklVFd8xke7zBxMeYJ5CGkduZA==",
+      "version": "2.44.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.44.0-alpha.0.tgz",
+      "integrity": "sha512-1ObXcC1AW4O2wx0xGLnXiw+QrnVGzuVBoK5v9tMxmzWA4Bo2ms4u3FL/3Ill36Q4925uqbRNdVS8zjN71DTAmQ==",
       "dev": true,
       "requires": {}
     },
@@ -6896,28 +6905,28 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.22.0.tgz",
-      "integrity": "sha512-oF3VCv/rtuLk8eLb6CBEWvEobabG8q05ersawGEy9CBhKbKNjfY1FDz6gc3ssksTwfcJqyJms2l/BQlLMBjugw==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.44.0.tgz",
+      "integrity": "sha512-9hbK4Yc1GQ28zSjZE2ajidt7sRrTLYpijkI7HT7JcDhXLe2ZGP9EOZrqKy5EEsOv0wDQ7cdXB3/oMiMGSmSQ5A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.22.0.tgz",
-      "integrity": "sha512-Orz+c746XGm1QBJKb3Wh6qH2rpmHdYMS5A4Wk91niYzrY4Q2kck/XLeQtEwOzscbW2Hqwc6vXTEpkldAI2pzGw==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.44.0.tgz",
+      "integrity": "sha512-h0lCcS3t2TPF5FIpkA7OcE2t4vChtz/FGcZ5jVaORj21quiUz84eOhGk2BeRoKqfSp1Zqu2QxQUk6p6YpAOrRA==",
       "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -6986,14 +6995,17 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true
         },
         "lru-cache": {
-          "version": "7.8.0",
+          "version": "6.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
         "minimatch": {
           "version": "3.1.2",
@@ -7009,15 +7021,20 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.6",
+          "version": "7.3.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
           }
         },
         "universalify": {
           "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },

--- a/cdk/nginxAuthentication/package.json
+++ b/cdk/nginxAuthentication/package.json
@@ -11,12 +11,12 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "aws-cdk-lib": "2.22.0",
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.22.0-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.22.0-alpha.0",
+    "aws-cdk-lib": "2.44.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "2.44.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.44.0-alpha.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "2.22.0",
+    "aws-cdk": "2.44.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",


### PR DESCRIPTION
…onstants to their newer equivalents.

*Issue #, if available:* n/a

*Description of changes:*

I updated to CDK 2.44.0.  After making that change, I had to change two of the EC2 Subnet CDK constants in `mlflow-vpc-stack.ts` as well.  I tested the deployment after making the change and it worked as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
